### PR TITLE
Handle type annotations for compound terms at the z3.py level

### DIFF
--- a/type_inference_global_backtrackable.pl
+++ b/type_inference_global_backtrackable.pl
@@ -45,13 +45,11 @@ assert_formula_list_types(L) :-
     set_map(Enew).
 
 
-assert_type(Term, Type) :- ground(Term), !,
+
+assert_type(Term, Type) :- must_be(ground, Term),
                            get_map(E),
                            typecheck(Term, Type, E, Enew),
                            set_map(Enew).
-assert_type(Term, _Type) :- \+ ground(Term),
-                            instantiation_error(Term).
-
 
 
 %%%%%%%%%%%% unit tests %%%%%%%%%%%

--- a/z3_swi_foreign.pl
+++ b/z3_swi_foreign.pl
@@ -329,6 +329,13 @@ test(neq_incompatible, [fail]) :-
 test(neq_numeric) :-
     z3_make_solver(S), reset_declarations(M), z3_assert(M, S, a:bool <> b:real), z3_solver_check(S, l_true).
 
+% The C code does not handle <compound_term>:int annotations.
+% The types for functions should be declared separately, if needed.
+% The higher-level API, z3.pl, does handle this case.
 
+test(nested_fail, [fail]) :-
+    z3_make_solver(S),
+    reset_declarations(M),
+    z3_assert(M, S, f(a:int):int = 3).
 
 :- end_tests(foreign_tests).


### PR DESCRIPTION
Handle type annotations for compound terms at the z3.py level, and clarify that the C level cannot.